### PR TITLE
Add redux-immutable-state-invariant, warning when the state is mutated (only in dev environment)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "redux-devtools": "3.2.0",
     "redux-devtools-dock-monitor": "1.1.1",
     "redux-devtools-log-monitor": "1.0.11",
+    "redux-immutable-state-invariant" : "1.2.3",
     "redux-slider-monitor": "1.0.5",
     "sass-loader": "3.1.2",
     "style-loader": "0.13.0",

--- a/src/js/store/configureStore.js
+++ b/src/js/store/configureStore.js
@@ -5,9 +5,13 @@ import { persistState } from 'redux-devtools';
 export default function configureStore(initialState) {
 
   let enhancer;
-  const middleware = applyMiddleware();
+  let middleware;
 
   if (process.env.NODE_ENV !== 'production') {
+
+    let middlewares = [require('redux-immutable-state-invariant')()];
+
+    middleware = applyMiddleware(...middlewares);
 
     let getDebugSessionKey = function () {
       // By default we try to read the key from ?debug_session=<key> in the address bar
@@ -27,6 +31,8 @@ export default function configureStore(initialState) {
       persistState(getDebugSessionKey())
     );
   } else {
+    let middlewares = [];
+    middleware = applyMiddleware(...middlewares);
     enhancer = compose(middleware);
   }
 


### PR DESCRIPTION
This might be a useful middleware to have on development environment. New Redux developers can be warned they're mutating the state and fix the errors.
