### PR TITLE
Enzyme for testing, react-redux-classconnect for less boilerplate

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "react": "15.0.1",
     "react-dom": "15.0.1",
     "react-redux": "4.4.5",
-    "react-redux-classconnect": "1.0.0",
+    "react-redux-classconnect": "1.0.1",
     "react-router": "2.3.0",
     "redux": "3.5.2"
   }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "colors": "1.1.2",
     "copy-webpack-plugin": "2.1.3",
     "css-loader": "0.23.1",
+    "enzyme": "2.3.0",
     "eslint": "2.8.0",
     "eslint-plugin-react": "5.0.1",
     "extract-text-webpack-plugin": "1.0.1",
@@ -77,6 +78,7 @@
     "react": "15.0.1",
     "react-dom": "15.0.1",
     "react-redux": "4.4.5",
+    "react-redux-classconnect": "1.0.0",
     "react-router": "2.3.0",
     "redux": "3.5.2"
   }

--- a/src/js/containers/FriendListApp/FriendListApp.js
+++ b/src/js/containers/FriendListApp/FriendListApp.js
@@ -1,18 +1,24 @@
 import './FriendListApp.scss';
 
 import React, { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import connect from 'react-redux-classconnect';
 
 import * as FriendsActions from '../../actions/FriendsActions';
 import { AddFriendInput, FriendList } from '../../components';
 
 class FriendListApp extends Component {
-
   static propTypes = {
     friendList: PropTypes.object.isRequired,
     actions: PropTypes.object.isRequired
   };
+
+  static stateProps = (state)=>({
+      friendList: state.friendList
+  })
+
+  static actionProps = {
+      actions: FriendsActions
+  }
 
   render () {
     const { friendList: { friendsById }, actions } = this.props;
@@ -27,19 +33,5 @@ class FriendListApp extends Component {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    friendList: state.friendList
-  };
-}
 
-function mapDispatchToProps(dispatch) {
-  return {
-    actions: bindActionCreators(FriendsActions, dispatch)
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(FriendListApp);
+export default connect(FriendListApp);

--- a/test/unit/containers/FriendListAppSpec.js
+++ b/test/unit/containers/FriendListAppSpec.js
@@ -1,19 +1,22 @@
-import { renderComponent, expect } from '../testHelper';
+import { configureContainer, expect } from '../testHelper';
 import FriendListApp from '../../../src/js/containers/FriendListApp/FriendListApp';
+
+
+import { shallow, mount, render } from 'enzyme';
 
 describe('FriendListApp', () => {
 
   let component;
 
   beforeEach(() => {
-    component = renderComponent(FriendListApp);
+    component = mount(configureContainer(FriendListApp))
   });
 
   it('shows an input to add a new friend', () => {
-    expect(component.find('.addFriendInput')).to.exist;
+    expect(component.find('.addFriendInput')).to.have.length(1);
   });
 
   it('shows a friend list', () => {
-    expect(component.find('.friendList')).to.exist;
+    expect(component.find('.friendList')).to.have.length(1);
   });
 });

--- a/test/unit/testHelper.js
+++ b/test/unit/testHelper.js
@@ -18,15 +18,10 @@ const $ = jq(window);
 // Set up chai-jquery
 chaiJquery(chai, chai.util, $);
 
-function renderComponent(ComponentClass, props = {}, state = {}) {
-  const componentInstance = ReactTestUtils.renderIntoDocument(
-    <Provider store={createStore(reducers, state)}>
+function configureContainer(ComponentClass, props = {}, state = {}) {
+  return <Provider store={createStore(reducers, state)}>
       <ComponentClass {...props} />
     </Provider>
-  );
-
-  // Produces HTML
-  return $(ReactDOM.findDOMNode(componentInstance));
 }
 
 function mockHistory(component) {
@@ -42,4 +37,4 @@ $.fn.simulate = function(eventName, value) {
   ReactTestUtils.Simulate[eventName](this[0]);
 };
 
-export { renderComponent, mockHistory, expect };
+export { configureContainer, mockHistory, expect };


### PR DESCRIPTION
Hi,
You can use this PR as a reference for an idea, but you can also merge it if you like what's inside. In either case feel free to close and not merge it if you like the idea but want to take it elsewhere.

Using `enzyme` most of the test helper infrastructure is not needed anymore (the implementation replaces what was there, and now it is safe to delete the jquery stuff).

Using `react-redux-classconnect` moves prop mapping into the component class and makes a better cognitive model.
