### PR TITLE
Remove history dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
   "dependencies": {
     "autoprefixer": "6.3.6",
     "classnames": "2.2.3",
-    "history": "2.1.0",
     "lodash": "4.11.1",
     "react": "15.0.1",
     "react-dom": "15.0.1",

--- a/test/unit/testHelper.js
+++ b/test/unit/testHelper.js
@@ -5,7 +5,7 @@ import ReactTestUtils from 'react-addons-test-utils';
 import jsdom from 'jsdom';
 import chai, { expect } from 'chai';
 import chaiJquery from 'chai-jquery';
-import createHistory from 'history/lib/createBrowserHistory';
+import createHistory from 'react-router/lib/browserHistory';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import reducers from '../../src/js/reducers';


### PR DESCRIPTION
Allows writing tests for presentational components without running into a ton of weird errors.

All I did was change `createHistory` to point to the one from `react-router`, and removed `history` from `package.json`.
