### PR TITLE
Fix lint command and errors raised by it

### DIFF
--- a/config/webpack.config.development.js
+++ b/config/webpack.config.development.js
@@ -3,7 +3,6 @@ const webpack = require('webpack');
 const config = require('./webpack.config.base');
 const path = require('path');
 
-
 const GLOBALS = {
   'process.env': {
     'NODE_ENV': JSON.stringify('development')

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "build": "cross-env NODE_ENV=production webpack --config ./config/webpack.config.production.js --progress",
     "postbuild": "npm run build:html",
     "build:serve": "http-server build/client -p 3003 --cors -o",
-    "lint": "eslint config src/js/** --ext .js",
+    "lint": "eslint config/ src/client/scripts/ src/client/assets/javascripts/ --ext .js",
     "jscs": "jscs src/js/",
     "typecheck": "flow",
     "test": "mocha --compilers js:babel-core/register,css:./test/unit/cssNullCompiler.js --require ./test/unit/testHelper.js --recursive ./test/unit",

--- a/src/client/assets/javascripts/app/Root.js
+++ b/src/client/assets/javascripts/app/Root.js
@@ -7,6 +7,8 @@ import { Router } from 'react-router';
 import routes from './routes';
 import { SENTRY_URL } from './config';
 
+/* global Raven */
+
 // If you use React Router, make this component
 // render <Router> with your routes. Currently,
 // only synchronous routes are hot reloaded, and

--- a/src/client/assets/javascripts/app/config.js
+++ b/src/client/assets/javascripts/app/config.js
@@ -2,6 +2,8 @@ const SENTRY_KEY = '488193c1894241789631f5a36188e3a5';
 const SENTRY_APP = '96144';
 export const SENTRY_URL = `https://${SENTRY_KEY}@sentry.io/${SENTRY_APP}`;
 
+/* global Raven */
+
 export function logException(ex, context) {
   Raven.captureException(ex, {
     extra: context


### PR DESCRIPTION
Due to the `no-multiple-empty-lines` option in ESLint configuration, an error is raised when running `npm run lint` because of two consecutive blank lines. I just removed one.

**Edit :**
The `npm run lint` command wasn't actually working as expected because none of the source files were parsed. So I added c368b69 .

I also noticed that JSCS was included in the dev dependencies and the command `npm run jscs` is pointing to /src/js (which doesn't exist). I checked JSCS and it seems to be deprecated in favor of ESLint.